### PR TITLE
Add dependency version matrix to CI

### DIFF
--- a/.github/workflows/build_publish_docker.yml
+++ b/.github/workflows/build_publish_docker.yml
@@ -11,7 +11,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "ubuntu-latest" ]
+        # Single configuration only.
+        # This is intentionally a matrix to centralize build parameters.
+        # Do not add additional entries here.
+        os: ["ubuntu-latest"]
+        librdkafka_version: ["1.4.4"]
+        zeek_kafka_version: ["1.2.0"]
     permissions:
       contents: write
       packages: write
@@ -123,5 +128,8 @@ jobs:
           push: true
           file: ./src/Dockerfile
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            LIBRDKAFKA_VERSION=${{ matrix.LIBRDKAFKA_VERSION }}
+            ZEEK_KAFKA_VERSION=${{ matrix.ZEEK_KAFKA_VERSION }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build_test_docker_matrix.yml
+++ b/.github/workflows/build_test_docker_matrix.yml
@@ -1,0 +1,47 @@
+name: Docker Compatibility Matrix CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build_test_docker:
+    name: Docker test on ${{ matrix.os }}, librdkafka ${{ matrix.librdkafka_version }}, zeek-kafka ${{ matrix.zeek_kafka_version }}
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-22.04", "ubuntu-24.04"]
+        librdkafka_version: ["1.4.4", "2.14.2"]
+        zeek_kafka_version: ["1.2.0"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./src/Dockerfile
+          push: false
+          load: false
+          platforms: linux/amd64
+          build-args: |
+            LIBRDKAFKA_VERSION=${{ matrix.librdkafka_version }}
+            ZEEK_KAFKA_VERSION=${{ matrix.zeek_kafka_version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false
+          sbom: false

--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,7 @@ docs/api/
 
 # requirements.txt
 !*/requirements.*.txt
+
+# IDEs
+.idea/
+.vscode/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,9 @@ services:
     build:
       context: ./
       dockerfile: ./src/Dockerfile
+      args:
+        LIBRDKAFKA_VERSION: 2.0.0
+        ZEEK_KAFKA_VERSION: 0.1.0
     cap_add:
       - NET_ADMIN
     network_mode: host

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -19,6 +19,9 @@ RUN cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=/opt/vcpkg/scripts/buildsystems/v
 # Stage 2: Final runtime image
 FROM zeek/zeek:8.0
 
+ARG LIBRDKAFKA_VERSION=1.4.4
+ARG ZEEK_KAFKA_VERSION=1.2.0
+
 # Combine package installation, builds, and cleanup in a single RUN
 # This ensures build tools like cmake and gcc don't bloat the final layer size
 RUN apt update -y && apt upgrade -y && apt install -y \
@@ -31,14 +34,14 @@ RUN apt update -y && apt upgrade -y && apt install -y \
     vim \
     pkg-config \
     iproute2 \
-    && curl -fsSL https://github.com/edenhill/librdkafka/archive/refs/tags/v1.4.4.tar.gz -o /tmp/librdkafka.tar.gz \
+    && curl -fsSL https://github.com/edenhill/librdkafka/archive/refs/tags/v${LIBRDKAFKA_VERSION}.tar.gz -o /tmp/librdkafka.tar.gz \
     && tar -xzf /tmp/librdkafka.tar.gz -C /tmp \
-    && cd /tmp/librdkafka-1.4.4 \
+    && cd /tmp/librdkafka-${LIBRDKAFKA_VERSION} \
     && ./configure --prefix=/usr/local \
     && make -j"$(nproc)" \
     && make install \
     && ldconfig \
-    && yes | zkg install seisollc/zeek-kafka --version v1.2.0 --user-var LIBRDKAFKA_ROOT=/usr/local \
+    && yes | zkg install seisollc/zeek-kafka --version v${ZEEK_KAFKA_VERSION} --user-var LIBRDKAFKA_ROOT=/usr/local \
     && setcap cap_net_raw,cap_net_admin=+eip $(which zeek) \
     && apt-get remove --purge -y build-essential cmake curl pkg-config \
     && apt-get autoremove -y \


### PR DESCRIPTION
This pull request introduces improved configurability and testing for Docker builds by parameterizing key dependency versions and adding a compatibility matrix CI workflow. The changes make it easier to build and test images with different versions of `librdkafka` and `zeek-kafka`, enhancing flexibility and reliability. This should fix #5.

**Docker build parameterization and version control:**

* Parameterized `LIBRDKAFKA_VERSION` and `ZEEK_KAFKA_VERSION` in the `src/Dockerfile`, allowing these dependencies' versions to be set via build arguments instead of being hardcoded. [[1]](diffhunk://#diff-f7c91877446336ef59ebfaacb472e50e4e40bbe54938f232b0fd54617eb6e7dcR22-R24) [[2]](diffhunk://#diff-f7c91877446336ef59ebfaacb472e50e4e40bbe54938f232b0fd54617eb6e7dcL34-R44)
* Updated `.github/workflows/build_publish_docker.yml` to use a build matrix (even with a single configuration) and to pass the relevant version build arguments to the Docker build step. [[1]](diffhunk://#diff-528ecb53a8bbbbfab8b5ddf0ac7e0d9c6f7c13d8f84dac217d18824dab6dcb6eR14-R19) [[2]](diffhunk://#diff-528ecb53a8bbbbfab8b5ddf0ac7e0d9c6f7c13d8f84dac217d18824dab6dcb6eR131-R133)
* Modified `docker-compose.yml` to specify `LIBRDKAFKA_VERSION` and `ZEEK_KAFKA_VERSION` as build arguments, ensuring local builds use explicit versions.

**Testing and CI improvements:**

* Added a new workflow `.github/workflows/build_test_docker_matrix.yml` that builds Docker images across a matrix of OS versions and dependency versions, improving test coverage and compatibility assurance.