### PR TITLE
Update organization name to ASTRAOS-de

### DIFF
--- a/.github/workflows/build_publish_docker.yml
+++ b/.github/workflows/build_publish_docker.yml
@@ -116,7 +116,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5.5.1
         with:
-          images: ghcr.io/hamstring-ndr/hamstring-zeek
+          images: ghcr.io/ASTRAOS-de/hamstring-zeek
           tags: |
             type=raw,value=latest
             type=raw,value=${{ steps.versioning.outputs.version }}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <!-- PROJECT LOGO -->
 <br />
 <div align="center">
-  <a href="https://github.com/hamstring-ndr/hamstring">
+  <a href="https://github.com/ASTRAOS-de/hamstring">
     <img src="https://avatars.githubusercontent.com/u/185810374?s=200&v=4" alt="Logo">
   </a>
 
@@ -12,9 +12,9 @@
     Zeek based module to ingest data in the main Hamstring application based on Apache Kafka queues.
     <br />
     <br>
-    <a href="https://github.com/hamstring-ndr/hamstring/issues/new?labels=bug&template=bug-report---.md">Report Bug</a>
+    <a href="https://github.com/ASTRAOS-de/hamstring/issues/new?labels=bug&template=bug-report---.md">Report Bug</a>
     ·
-    <a href="https://github.com/hamstring-ndr/hamstring/issues/new?labels=enhancement&template=feature-request---.md">Request Feature</a>
+    <a href="https://github.com/ASTRAOS-de/hamstring/issues/new?labels=enhancement&template=feature-request---.md">Request Feature</a>
   </p>
 </div>
 <br>
@@ -22,11 +22,11 @@
 <tr>
   <td><b>Continuous Integration</b></td>
   <td>
-    <a href="https://github.com/hamstring-ndr/hamstring-zeek/actions/workflows/build_test_linux.yml">
-    <img src="https://img.shields.io/github/actions/workflow/status/hamstring-ndr/hamstring-zeek/build_test_linux.yml?branch=main&logo=linux&style=for-the-badge&label=linux" alt="Linux WorkFlows" />
+    <a href="https://github.com/ASTRAOS-de/hamstring-zeek/actions/workflows/build_test_linux.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/ASTRAOS-de/hamstring-zeek/build_test_linux.yml?branch=main&logo=linux&style=for-the-badge&label=linux" alt="Linux WorkFlows" />
     </a>
-    <a href="https://github.com/hamstring-ndr/hamstring-zeek/actions/workflows/build_test_macos.yml">
-    <img src="https://img.shields.io/github/actions/workflow/status/hamstring-ndr/hamstring-zeek/build_test_macos.yml?branch=main&logo=apple&style=for-the-badge&label=macos" alt="MacOS WorkFlows" />
+    <a href="https://github.com/ASTRAOS-de/hamstring-zeek/actions/workflows/build_test_macos.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/ASTRAOS-de/hamstring-zeek/build_test_macos.yml?branch=main&logo=apple&style=for-the-badge&label=macos" alt="MacOS WorkFlows" />
     </a>
   </td>
 </tr>
@@ -41,7 +41,7 @@
 ```sh
 docker compose up
 ```
-Please note that in order for the module to work, you need to have an instance of Hamstring running. To do so, please refer to the [official hamstring repository](https://github.com/Hamstring-NDR/hamstring).
+Please note that in order for the module to work, you need to have an instance of Hamstring running. To do so, please refer to the [official hamstring repository](https://github.com/ASTRAOS-de/hamstring).
 
 ## Building
 


### PR DESCRIPTION
This pull request updates repository references throughout the project to point to the new `ASTRAOS-de` organization instead of the previous `hamstring-ndr` organization. The changes ensure that all documentation, Docker image publishing, and CI status badges reference the correct GitHub organization and repositories. This should fix the latest CI/CD failure.

Repository reference updates:

* Updated all GitHub repository links in the `README.md` file to use the `ASTRAOS-de` organization, including project links, issue reporting, feature requests, and CI workflow badges. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R5) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L15-R29)
* Updated the documentation to refer to the official Hamstring repository under `ASTRAOS-de` for setup instructions.

Docker and CI configuration:

* Updated the Docker image publishing configuration in `.github/workflows/build_publish_docker.yml` to push images to `ghcr.io/ASTRAOS-de/hamstring-zeek` instead of the old organization.